### PR TITLE
Tree deletion improvement

### DIFF
--- a/Engine/ProductRuleApplier/ProductsUpdater.php
+++ b/Engine/ProductRuleApplier/ProductsUpdater.php
@@ -92,21 +92,22 @@ class ProductsUpdater extends BaseProductsUpdater
      */
     protected function applySetCategoryAction(array $products, ProductSetCategoryActionInterface $action)
     {
-        $category = $this->getCategory($action->getCategoryCode());
+        $category = ($action->getCategoryCode()) ? $this->getCategory($action->getCategoryCode()) : null;
         $tree     = ($action->getTreeCode()) ? $this->getCategory($action->getTreeCode()) : null;
 
         foreach ($products as $product) {
             // Remove categories (only a tree if asked) from the product
-            $categories = $product->getCategories();
-            foreach ($categories as $category) {
+            foreach ($product->getCategories() as $currentCategory) {
                 if (null === $tree) {
-                    $product->removeCategory($category);
-                } else if ($category->getRoot() === $tree->getId()) {
-                    $product->removeCategory($category);
+                    $product->removeCategory($currentCategory);
+                } elseif ($currentCategory->getRoot() === $tree->getId()) {
+                    $product->removeCategory($currentCategory);
                 }
             }
 
-            $product->addCategory($category);
+            if (null !== $category) {
+                $product->addCategory($category);
+            }
         }
 
         return $this;
@@ -122,7 +123,7 @@ class ProductsUpdater extends BaseProductsUpdater
     protected function getCategory($categoryCode)
     {
         $category = $this->categoryRepository->findOneByIdentifier($categoryCode);
-        if (null !== $category) {
+        if (null === $category) {
             throw new EntityNotFoundException(
                 sprintf(
                     'Impossible to apply rule to on this category cause the category "%s" does not exist',

--- a/Model/ProductAddCategoryActionInterface.php
+++ b/Model/ProductAddCategoryActionInterface.php
@@ -14,6 +14,7 @@ use Akeneo\Bundle\RuleEngineBundle\Model\ActionInterface;
  */
 interface ProductAddCategoryActionInterface extends ActionInterface
 {
+    /** @staticvar string */
     const ACTION_TYPE = 'add_category';
 
     /**

--- a/Model/ProductSetCategoryAction.php
+++ b/Model/ProductSetCategoryAction.php
@@ -25,7 +25,6 @@ class ProductSetCategoryAction extends AbstractCategoryAction implements Product
         $this->treeCode = isset($data['treeCode']) ? $data['treeCode'] : null;
     }
 
-
     /**
      * {@inheritdoc}
      */

--- a/Model/ProductSetCategoryAction.php
+++ b/Model/ProductSetCategoryAction.php
@@ -12,4 +12,35 @@ namespace PimEnterprise\Bundle\ClassificationRuleBundle\Model;
  */
 class ProductSetCategoryAction extends AbstractCategoryAction implements ProductSetCategoryActionInterface
 {
+    /** @var string */
+    protected $treeCode;
+
+    /**
+     * @param array $data
+     */
+    public function __construct(array $data)
+    {
+        parent::__construct($data);
+
+        $this->treeCode = isset($data['treeCode']) ? $data['treeCode'] : null;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTreeCode()
+    {
+        return $this->treeCode;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTreeCode($treeCode)
+    {
+        $this->treeCode = $treeCode;
+
+        return $this;
+    }
 }

--- a/Model/ProductSetCategoryActionInterface.php
+++ b/Model/ProductSetCategoryActionInterface.php
@@ -14,17 +14,30 @@ use Akeneo\Bundle\RuleEngineBundle\Model\ActionInterface;
  */
 interface ProductSetCategoryActionInterface extends ActionInterface
 {
+    /** @staticvar string */
     const ACTION_TYPE = 'set_category';
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getCategoryCode();
 
     /**
      * @param string $categoryCode
      *
-     * @return ProductAddCategoryActionInterface
+     * @return ProductSetCategoryActionInterface
      */
     public function setCategoryCode($categoryCode);
+
+    /**
+     * @return string|null
+     */
+    public function getTreeCode();
+
+    /**
+     * @param string $treeCode
+     *
+     * @return ProductSetCategoryActionInterface
+     */
+    public function setTreeCode($treeCode);
 }

--- a/README.md
+++ b/README.md
@@ -8,17 +8,7 @@ A bundle that extend the Pim Enterprise CatalogRuleBundle, adding the possibilit
 
 ## Installation
 
-As the Git repository is private, you need to add it to the composer.json of your project:
-
-    "repositories": [
-            {
-                "type": "vcs",
-                "url": "https://github.com/akeneo-labs/ClassificationRuleBundle.git",
-                "branch": "master"
-            }
-        ]
-
-Then install the bundle with composer:
+You can install the bundle with composer:
 
     $ php composer.phar require akeneo-labs/classification-rule-bundle:1.0.*
 
@@ -40,7 +30,9 @@ Then clean the cache:
 This bundle is an extension of the CatalogRuleBundle, so it uses the same conditions, and add a new set of actions:
 
 * `add_category`: add a product to a category,
-* `set_category`: add a product to a category and remove it from all other category. If you set the category code to `null`, it will declassify the product.
+* `set_category`: add a product to a category and remove it from all other category.
+If you set the category code to `null`, it will declassify the product.
+You can also define a tree to declassify only the product's categories of this tree.
 
 The category must exists, or the rule will not apply.
 
@@ -84,5 +76,15 @@ The category must exists, or the rule will not apply.
             actions:
                 - type:         set_category
                   categoryCode: null
+        led_tvs_remove_category_on_master_tree:
+            conditions:
+                - field:    family.code
+                  operator: IN
+                  value:
+                    - led_tvs
+            actions:
+                - type:     set_category
+                  treeCode: master
+
 
 Take a look to [icecat_demo_dev rule fixtures](https://github.com/akeneo/pim-enterprise-dev/blob/1.3/src/PimEnterprise/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/rules.yml) to see more examples of conditions.


### PR DESCRIPTION
Two improvements on this PR.
First is on performance, throwing an exception if the category defined in the rule is not found. It avoids to call doctrine for each product and to continue to run a rule that is not applicable.

The second one is about tree management. Most of the time, we don't want to reset categories but we just want to reset them on a specific tree (to replace them by another for example one). Now you can define a tree in your rule to avoid removing categories from all the trees.

| Q                    | A
| -------------------- | ---
| Bug fix?             | N
| New feature?         | Y
| BC breaks?           | N/A
| Tests pass?          | Y
| Checkstyle issues?*  | N
| PMD issues?**        | ?
| Changelog updated?   | N/A
| Fixed tickets        | N/A
| DB schema updated?   | N/A
| Migration script?    |
| Doc PR               |